### PR TITLE
Add example cherrypy+celery+peewee

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,20 @@ language: python
 python:
 - 2.7
 - 3.6
-
+services:
+- redis-server
 stages:
 - lint
 - test
 
+env:
+  BROKER_URL: redis://localhost:6379/0
+
 script:
+- coverage run --include='pacifica/*' -p -m celery -A pacifica.example.tasks worker -c 1 -P solo -l info &
 - coverage run --include='pacifica/*' -m pytest -v
+- celery -A pacifica.example.tasks control shutdown || true
+- coverage combine -a .coverage*
 - coverage report -m --fail-under 100
 - if [[ $CODECLIMATE_REPO_TOKEN ]] ; then codeclimate-test-reporter; fi
 
@@ -22,3 +29,4 @@ jobs:
 
 install:
 - pip install -r requirements-dev.txt
+- pip install 'celery[redis]'

--- a/Dockerfile.celery
+++ b/Dockerfile.celery
@@ -1,0 +1,14 @@
+FROM python:3.6
+
+WORKDIR /usr/src/app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir pymysql psycopg2
+ENV PEEWEE_PROTO mysql
+ENV PEEWEE_USER notifications
+ENV PEEWEE_PASS notifications
+ENV PEEWEE_PORT 3306
+ENV PEEWEE_ADDR 127.0.0.1
+ENV PEEWEE_DATABASE pacifica_notifications
+COPY . .
+ENTRYPOINT [ "/bin/bash", "/usr/src/app/entrypoint-celery.sh" ]

--- a/Dockerfile.uwsgi
+++ b/Dockerfile.uwsgi
@@ -1,0 +1,16 @@
+FROM python:3.6
+
+WORKDIR /usr/src/app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir uwsgi pymysql psycopg2
+ENV PEEWEE_PROTO mysql
+ENV PEEWEE_USER notifications
+ENV PEEWEE_PASS notifications
+ENV PEEWEE_PORT 3306
+ENV PEEWEE_ADDR 127.0.0.1
+ENV PEEWEE_DATABASE pacifica_notifications
+ENV NOTIFICATIONS_CPCONFIG /usr/src/app/server.conf
+COPY . .
+EXPOSE 8066
+ENTRYPOINT [ "/bin/bash", "/usr/src/app/entrypoint.sh" ]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Pacifica Template Repository
 [![Build Status](https://travis-ci.org/pacifica/template-repository.svg?branch=master)](https://travis-ci.org/pacifica/template-repository)
 [![Build status](https://ci.appveyor.com/api/projects/status/eg2r1y37yvxi0b5p?svg=true)](https://ci.appveyor.com/project/dmlb2000/template-repository)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/d6149dbe182a3c761089/test_coverage)](https://codeclimate.com/github/pacifica/template-repository/test_coverage)
 [![Maintainability](https://api.codeclimate.com/v1/badges/f2dba248b1a7966e5a49/maintainability)](https://codeclimate.com/github/pacifica/template-repository/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/f2dba248b1a7966e5a49/test_coverage)](https://codeclimate.com/github/pacifica/template-repository/test_coverage)
 
@@ -9,3 +8,65 @@ This repository is to serve as a template for building new
 services the Pacifica way. This repository has pipelines
 for travis and appveyor to build your code and pre-commit
 and pytest to fix your code.
+
+## The Parts
+
+There are several parts to this code as it encompasses
+integrating several python libraries together.
+
+ * [PeeWee](http://docs.peewee-orm.com/en/latest/)
+ * [CherryPy](https://cherrypy.org/)
+ * [Celery](http://www.celeryproject.org/)
+
+For each major library we have integration points in
+specific modules to handle configuration of each library.
+
+### PeeWee
+
+The configuration of PeeWee is pulled from an INI file parsed
+from an environment variable or command line option. The
+configuration in the file is a database
+[connection url](http://docs.peewee-orm.com/en/latest/peewee/database.html#connecting-using-a-database-url).
+
+ * [Example PeeWee Model](pacifica/example/orm.py)
+ * [Example Config Parser](pacifica/example/config.py)
+
+### CherryPy
+
+The CherryPy configuration has two entrypoints for use. The
+WSGI interface and the embedded server through the main
+method.
+
+ * [Example Main Method](pacifica/example/__main__.py)
+ * [Example WSGI API](pacifica/example/wsgi.py)
+ * [Example CherryPy Objects](pacifica/example/rest.py)
+
+### Celery
+
+The Celery tasks are located in their own module and have
+an entrypoint from the CherryPy REST objects. The tasks
+save state into a PeeWee database that is also accessed
+in the CherryPy REST objects.
+
+ * [Example Tasks](pacifica/example/tasks.py)
+
+## Start Up Process
+
+The default way to start up this service is with a shared
+SQLite database. The database must be located in the
+current working directory of both the celery workers and
+the CherryPy web server. The messaging system in
+[Travis](.travis.yml) and [Appveyor](appveyor.yml) is
+redis, however the default is rabbitmq.
+
+There are three commands needed to start up the services.
+Perform these steps in three separate terminals.
+
+ 1. `docker-compose up rabbit`
+ 2. `celery -A pacifica.example.tasks worker -l info`
+ 3. `python -m pacifica.example`
+
+To test working system run the following in bash:
+
+ 1. `UUID=$(curl http://127.0.0.1:8069/dispatch/add/2/2)`
+ 2. `curl http://127.0.0.1:8069/status/$UUID`

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,7 @@ pull_requests:
   do_not_increment_build_number: true
 
 environment:
+  BROKER_URL: redis://localhost:6379/0
   matrix:
     - PYTHON: C:\Python27-x64
     - PYTHON: C:\Python36-x64
@@ -12,7 +13,14 @@ install:
       & "$env:PYTHON\python.exe" -m virtualenv C:\pacifica;
       C:\pacifica\Scripts\activate.ps1;
       python -m pip install --upgrade pip setuptools wheel;
-      python -m pip install -r requirements-dev.txt
+      python -m pip install -r requirements-dev.txt;
+      python -m pip install 'celery[eventlet]' 'celery[redis]' redis eventlet;
+
+before_test:
+  - ps: >
+      nuget install redis-64 -excludeversion;
+      redis-64\tools\redis-server.exe --service-install;
+      redis-64\tools\redis-server.exe --service-start;
 
 build: off
 
@@ -20,5 +28,9 @@ test_script:
   - ps: >
       mkdir C:\tmp; C:\pacifica\Scripts\activate.ps1;
       pre-commit run -a;
+      $celery_proc = Start-Process C:\pacifica\Scripts\coverage.exe -ArgumentList "run --include=pacifica/* -p -m celery -A pacifica.example.tasks worker -l info -c 1 -P solo" -RedirectStandardError celery-error.log -RedirectStandardOutput celery-output.log;
       coverage run --include='pacifica/*' -m pytest -v;
+      python -m celery -A pacifica.example.tasks control shutdown;
+      $celery_proc | Wait-Process;
+      ls .coverage* | %{ python -m coverage combine -a $_.name };
       coverage report -m --fail-under=100;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,40 @@
+version: '3.3'
+services:
+  frontend:
+    build:
+      context: .
+      dockerfile: Dockerfile.uwsgi
+    links:
+    - rabbit
+    - mysql
+    ports:
+    - 8069:8069
+    environment:
+      PEEWEE_ADDR: mysql
+      BROKER_URL: pyamqp://guest:guest@rabbit:5672//
+
+  backend:
+    build:
+      context: .
+      dockerfile: Dockerfile.celery
+    links:
+     - rabbit
+     - mysql
+    environment:
+      PEEWEE_ADDR: mysql
+      BROKER_URL: pyamqp://guest:guest@rabbit:5672//
+
+  mysql:
+    image: mysql:5
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: pacifica_example
+      MYSQL_USER: example
+      MYSQL_PASSWORD: example
+    ports:
+     - 3306:3306
+
+  rabbit:
+    image: rabbitmq
+    ports:
+     - 5672:5672

--- a/entrypoint-celery.sh
+++ b/entrypoint-celery.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+if [[ -z $PEEWEE_DATABASE_URL ]] ; then
+  if [[ $PEEWEE_USER && $PEEWEE_PASS ]]; then
+    PEEWEE_USER_PART="${PEEWEE_USER}:${PEEWEE_PASS}@"
+  fi
+  if [[ $PEEWEE_PORT ]] ; then
+    PEEWEE_ADDR_PART="${PEEWEE_ADDR}:${PEEWEE_PORT}"
+  else
+    PEEWEE_ADDR_PART=$PEEWEE_ADDR
+  fi
+  PEEWEE_DATABASE_URL="${PEEWEE_PROTO}://${PEEWEE_USER_PART}${PEEWEE_ADDR_PART}/${PEEWEE_DATABASE}"
+fi
+mkdir ~/.pacifica-example/
+printf '[database]\npeewee_url = '${PEEWEE_DATABASE_URL}'\n' > ~/.pacifica-example/config.ini
+celery -A pacifica.example.tasks worker --loglevel=info

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+if [[ -z $PEEWEE_DATABASE_URL ]] ; then
+  if [[ $PEEWEE_USER && $PEEWEE_PASS ]]; then
+    PEEWEE_USER_PART="${PEEWEE_USER}:${PEEWEE_PASS}@"
+  fi
+  if [[ $PEEWEE_PORT ]] ; then
+    PEEWEE_ADDR_PART="${PEEWEE_ADDR}:${PEEWEE_PORT}"
+  else
+    PEEWEE_ADDR_PART=$PEEWEE_ADDR
+  fi
+  PEEWEE_DATABASE_URL="${PEEWEE_PROTO}://${PEEWEE_USER_PART}${PEEWEE_ADDR_PART}/${PEEWEE_DATABASE}"
+fi
+mkdir ~/.pacifica-example/
+printf '[database]\npeewee_url = '${PEEWEE_DATABASE_URL}'\n' > ~/.pacifica-example/config.ini
+python -c 'from pacifica.example.orm import database_setup; database_setup()'
+uwsgi \
+  --http-socket 0.0.0.0:8069 \
+  --master \
+  --die-on-term \
+  --wsgi-file /usr/src/app/pacifica/example/wsgi.py "$@"

--- a/pacifica/example/__main__.py
+++ b/pacifica/example/__main__.py
@@ -1,0 +1,58 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+"""The main module for executing the CherryPy server."""
+from time import sleep
+from argparse import ArgumentParser, SUPPRESS
+from threading import Thread
+import cherrypy
+from pacifica.example.orm import database_setup
+from pacifica.example.rest import Root, error_page_default
+from pacifica.example.globals import CHERRYPY_CONFIG
+
+
+def stop_later(doit=False):
+    """Used for unit testing stop after 60 seconds."""
+    if not doit:  # pragma: no cover
+        return
+
+    def sleep_then_exit():
+        """
+        Sleep for 20 seconds then call cherrypy exit.
+
+        Hopefully this is long enough for the end-to-end tests to finish
+        """
+        sleep(20)
+        cherrypy.engine.exit()
+    sleep_thread = Thread(target=sleep_then_exit)
+    sleep_thread.daemon = True
+    sleep_thread.start()
+
+
+def main():
+    """Main method to start the httpd server."""
+    parser = ArgumentParser(description='Run the notifications server.')
+    parser.add_argument('-c', '--config', metavar='CONFIG', type=str,
+                        default=CHERRYPY_CONFIG, dest='config',
+                        help='cherrypy config file')
+    parser.add_argument('-p', '--port', metavar='PORT', type=int,
+                        default=8069, dest='port',
+                        help='port to listen on')
+    parser.add_argument('-a', '--address', metavar='ADDRESS',
+                        default='localhost', dest='address',
+                        help='address to listen on')
+    parser.add_argument('--stop-after-a-moment', help=SUPPRESS,
+                        default=False, dest='stop_later',
+                        action='store_true')
+    args = parser.parse_args()
+    database_setup()
+    stop_later(args.stop_later)
+    cherrypy.config.update({'error_page.default': error_page_default})
+    cherrypy.config.update({
+        'server.socket_host': args.address,
+        'server.socket_port': args.port
+    })
+    cherrypy.quickstart(Root(), '/', args.config)
+
+
+if __name__ == '__main__':
+    main()

--- a/pacifica/example/config.py
+++ b/pacifica/example/config.py
@@ -1,0 +1,18 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+"""Configuration reading and validation module."""
+try:
+    from ConfigParser import SafeConfigParser
+except ImportError:  # pragma: no cover python 2 vs 3 issue
+    from configparser import SafeConfigParser
+from pacifica.example.globals import CONFIG_FILE
+
+
+def get_config():
+    """Return the ConfigParser object with defaults set."""
+    configparser = SafeConfigParser({
+        'peewee_url': 'sqliteext:///db.sqlite3'
+    })
+    configparser.add_section('database')
+    configparser.read(CONFIG_FILE)
+    return configparser

--- a/pacifica/example/globals.py
+++ b/pacifica/example/globals.py
@@ -1,0 +1,10 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+"""Global configuration options expressed in environment variables."""
+from os import getenv
+from os.path import expanduser, join
+
+CONFIG_FILE = getenv('EXAMPLE_CONFIG', join(
+    expanduser('~'), '.pacifica-example', 'config.ini'))
+CHERRYPY_CONFIG = getenv('EXAMPLE_CPCONFIG', join(
+    expanduser('~'), '.pacifica-example', 'cpconfig.ini'))

--- a/pacifica/example/orm.py
+++ b/pacifica/example/orm.py
@@ -1,0 +1,53 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+"""The ORM module defining the SQL model for example."""
+import uuid
+from datetime import datetime
+from peewee import Model, CharField, DateTimeField, UUIDField
+from playhouse.db_url import connect
+from pacifica.example.config import get_config
+
+DB = connect(get_config().get('database', 'peewee_url'))
+
+
+def database_setup():
+    """Setup the database."""
+    ExampleModel.database_setup()
+
+
+class ExampleModel(Model):
+    """Example saving some name data."""
+
+    uuid = UUIDField(primary_key=True, default=uuid.uuid4, index=True)
+    value = CharField(index=True)
+    created = DateTimeField(default=datetime.now, index=True)
+    updated = DateTimeField(default=datetime.now, index=True)
+    deleted = DateTimeField(null=True, index=True)
+
+    # pylint: disable=too-few-public-methods
+    class Meta(object):
+        """The meta class that contains db connection."""
+
+        database = DB
+    # pylint: enable=too-few-public-methods
+
+    @classmethod
+    def database_setup(cls):
+        """Setup the database by creating all tables."""
+        if not cls.table_exists():
+            cls.create_table()
+
+    @classmethod
+    def connect(cls):
+        """Connect to the database."""
+        cls._meta.database.connect(True)
+
+    @classmethod
+    def close(cls):
+        """Close the connection to the database."""
+        cls._meta.database.close()
+
+    @classmethod
+    def atomic(cls):
+        """Do the database atomic action."""
+        return cls._meta.database.atomic()

--- a/pacifica/example/rest.py
+++ b/pacifica/example/rest.py
@@ -1,0 +1,60 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+"""CherryPy module containing classes for rest interface."""
+from json import dumps
+import cherrypy
+from cherrypy import HTTPError
+from peewee import DoesNotExist
+from pacifica.example.orm import ExampleModel
+from pacifica.example.tasks import example_task
+
+
+def error_page_default(**kwargs):
+    """The default error page should always enforce json."""
+    cherrypy.response.headers['Content-Type'] = 'application/json'
+    return dumps({
+        'status': kwargs['status'],
+        'message': kwargs['message'],
+        'traceback': kwargs['traceback'],
+        'version': kwargs['version']
+    })
+
+
+# pylint: disable=too-few-public-methods
+class Dispatch(object):
+    """CherryPy EventMatch endpoint."""
+
+    exposed = True
+
+    @staticmethod
+    # pylint: disable=invalid-name
+    def GET(method, *numbers):
+        """Get the event ID and return it."""
+        return str(example_task.delay(method, *numbers))
+
+
+# pylint: disable=too-few-public-methods
+class Status(object):
+    """CherryPy Receive Event object."""
+
+    exposed = True
+
+    @staticmethod
+    # pylint: disable=invalid-name
+    def GET(uuid):
+        """Receive the event and dispatch it to backend."""
+        try:
+            return str(ExampleModel.get(uuid=uuid).value)
+        except DoesNotExist:
+            raise HTTPError('404', 'Not Found')
+# pylint: enable=too-few-public-methods
+
+
+# pylint: disable=too-few-public-methods
+class Root(object):
+    """CherryPy Root Object."""
+
+    exposed = True
+    dispatch = Dispatch()
+    status = Status()
+# pylint: enable=too-few-public-methods

--- a/pacifica/example/tasks.py
+++ b/pacifica/example/tasks.py
@@ -1,0 +1,43 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+"""The Celery tasks module."""
+from os import getenv
+from celery import Celery, Task
+from pacifica.example import Example
+from pacifica.example.orm import ExampleModel
+
+CELERY_APP = Celery(
+    'notifications',
+    broker=getenv('BROKER_URL', 'pyamqp://'),
+    backend=getenv('BACKEND_URL', 'rpc://')
+)
+
+
+# pylint: disable=too-few-public-methods
+# pylint: disable=abstract-method
+class ExampleTask(Task):
+    """Example Task Class."""
+
+    def on_success(self, retval, task_id, args, kwargs):
+        """On success save the return value to DB."""
+        super(ExampleTask, self).on_success(retval, task_id, args, kwargs)
+        new_task = ExampleModel(
+            uuid=task_id,
+            value=retval
+        )
+        ExampleModel.connect()
+        with ExampleModel.atomic():
+            new_task.save(force_insert=True)
+        ExampleModel.close()
+
+
+@CELERY_APP.task(base=ExampleTask)
+def example_task(method_str, *numbers):
+    """Get all the events and see which match."""
+    numbers_copy = []
+    for value in numbers:
+        try:
+            numbers_copy.append(int(value))
+        except ValueError:
+            numbers_copy.append(value)
+    return getattr(Example, method_str)(*numbers_copy)

--- a/pacifica/example/test/rest_test.py
+++ b/pacifica/example/test/rest_test.py
@@ -1,0 +1,82 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+"""Test the rest interface."""
+from time import sleep
+import requests
+import cherrypy
+from cherrypy.test import helper
+from pacifica.example.orm import database_setup, ExampleModel
+from pacifica.example.rest import Root, error_page_default
+
+
+def examplemodel_droptables(func):
+    """Setup the database and drop it once done."""
+    def wrapper(*args, **kwargs):
+        """Create the database table."""
+        database_setup()
+        func(*args, **kwargs)
+        ExampleModel.drop_table()
+    return wrapper
+
+
+class ExampleCPTest(helper.CPWebCase):
+    """Base class for all testing classes."""
+
+    HOST = '127.0.0.1'
+    PORT = 8069
+    url = 'http://{0}:{1}'.format(HOST, PORT)
+    headers = {'content-type': 'application/json'}
+
+    @staticmethod
+    def setup_server():
+        """Bind tables to in memory db and start service."""
+        cherrypy.config.update({'error_page.default': error_page_default})
+        cherrypy.config.update('server.conf')
+        cherrypy.tree.mount(Root(), '/', 'server.conf')
+
+    @examplemodel_droptables
+    def test_default_mul(self):
+        """Test a default summation in example."""
+        resp = requests.get('http://127.0.0.1:8069/dispatch/mul/2/2')
+        self.assertEqual(resp.status_code, 200)
+        uuid = resp.text
+        sleep(2)
+        resp = requests.get('http://127.0.0.1:8069/status/{}'.format(uuid))
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(int(resp.text), 4)
+
+    @examplemodel_droptables
+    def test_default_sum(self):
+        """Test a default summation in example."""
+        resp = requests.get('http://127.0.0.1:8069/dispatch/add/2/2')
+        self.assertEqual(resp.status_code, 200)
+        uuid = resp.text
+        sleep(2)
+        resp = requests.get('http://127.0.0.1:8069/status/{}'.format(uuid))
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(int(resp.text), 4)
+
+    @examplemodel_droptables
+    def test_string_mul(self):
+        """Test a default summation in example."""
+        resp = requests.get('http://127.0.0.1:8069/dispatch/mul/a/2')
+        self.assertEqual(resp.status_code, 200)
+        uuid = resp.text
+        resp = requests.get('http://127.0.0.1:8069/status/{}'.format(uuid))
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.text, 'aa')
+
+    @examplemodel_droptables
+    def test_error_sum(self):
+        """Test a default summation in example."""
+        resp = requests.get('http://127.0.0.1:8069/dispatch/add/2/2/2')
+        self.assertEqual(resp.status_code, 200)
+        uuid = resp.text
+        resp = requests.get('http://127.0.0.1:8069/status/{}'.format(uuid))
+        self.assertEqual(resp.status_code, 404)
+
+    @examplemodel_droptables
+    def test_error_json(self):
+        """Test a default summation in example."""
+        resp = requests.get('http://127.0.0.1:8069/status')
+        self.assertEqual(resp.status_code, 500)

--- a/pacifica/example/wsgi.py
+++ b/pacifica/example/wsgi.py
@@ -1,0 +1,12 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+"""The WSGI interface module for notifications."""
+import cherrypy
+from pacifica.example.rest import Root, error_page_default
+from pacifica.example.globals import CHERRYPY_CONFIG
+
+cherrypy.config.update({'error_page.default': error_page_default})
+# pylint doesn't realize that application is actually a callable
+# pylint: disable=invalid-name
+application = cherrypy.Application(Root(), '/', CHERRYPY_CONFIG)
+# pylint: enable=invalid-name

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,12 @@
+celery
+cherrypy
 codeclimate-test-reporter
 coverage>4.0,<4.4
+peewee
 pep257
 pre-commit
 pre-commit
 pylint<2.0
 pytest
+requests
 setuptools

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
+celery
+cherrypy
+peewee
 setuptools
 six

--- a/server.conf
+++ b/server.conf
@@ -1,0 +1,10 @@
+[global]
+log.screen: True
+log.access_file: 'access.log'
+log.error_file: 'error.log'
+server.socket_host: '0.0.0.0'
+server.socket_port: 8069
+engine.autoreload.on: False
+
+[/]
+request.dispatch: cherrypy.dispatch.MethodDispatcher()

--- a/setup.py
+++ b/setup.py
@@ -19,5 +19,10 @@ setup(
     author_email='david.brown@pnnl.gov',
     packages=find_packages(),
     namespace_packages=['pacifica'],
+    entry_points={
+        'console_scripts': [
+            'pacifica-example=pacifica.example.__main__:main'
+        ]
+    },
     install_requires=[str(ir.req) for ir in INSTALL_REQS]
 )


### PR DESCRIPTION
### Description

This adds basic place holders for cherrypy rest services,
peewee database models and celery tasks. This also provides
a basic model of how to save state using celery task uuids.

Signed-off-by: David Brown <dmlb2000@gmail.com>

### Issues Resolved
Fix #2

### Check List

- [x] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
